### PR TITLE
Remove support for Python 2.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,6 @@ matrix:
       env: TOXENV=py36
     - python: 3.5
       env: TOXENV=py35
-    - python: 2.7
-      env: TOXENV=py27
 
 
 install:

--- a/itests/integration_test_resource_manager.py
+++ b/itests/integration_test_resource_manager.py
@@ -4,12 +4,8 @@ import os
 
 from pprint import pprint
 from unittest import TestCase
+from urllib.parse import urlparse
 from yarn_api_client.resource_manager import ResourceManager
-
-try:
-    from urlparse import urlparse
-except ImportError:
-    from urllib.parse import urlparse
 
 
 class ResourceManagerTestCase(TestCase):

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bdist_wheel]
-universal=1
+universal=0
 
 [metadata]
 description-file=README.rst

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,6 @@ setup(
         'Intended Audience :: Developers',
         'License :: OSI Approved :: BSD License',
         'Operating System :: OS Independent',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py35,py36,py37,py38
+envlist = py35,py36,py37,py38
 
 [testenv]
 deps =

--- a/yarn_api_client/base.py
+++ b/yarn_api_client/base.py
@@ -6,13 +6,9 @@ import os
 import requests
 
 from datetime import datetime
+from urllib.parse import urlparse, urlunparse
 
 from .errors import APIError, ConfigurationError
-
-try:
-    from urlparse import urlparse, urlunparse
-except ImportError:
-    from urllib.parse import urlparse, urlunparse
 
 
 def get_logger(logger_name):


### PR DESCRIPTION
These changes remove support for Python 2.7 since our builds are now breaking (#85).  This does not preclude the use of Hadoop YARN 2.7-based systems, just that the yarn-client app must be invoked from Python 3.5+.