### PR TITLE
One-line pip install from git

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,10 +34,7 @@ conda install -c conda-forge yarn-api-client
 
 From source code
 ```
-git clone https://github.com/toidi/hadoop-yarn-api-python-client.git
-pushd hadoop-yarn-api-python-client
-python setup.py install
-popd
+pip install git+https://github.com/CODAIT/hadoop-yarn-api-python-client.git
 ```
 
 ## Enabling support for Kerberos/SPNEGO Security


### PR DESCRIPTION
This should be more straightforward one-liner for git install + update link to latest CODAIT repo (instead of old one)