### PR TITLE
Fix 3.6 build failures

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,7 @@ envlist = py35,py36,py37,py38,py39
 deps =
     coverage
     mock
+    py36: cryptography<=3.2.2  # requests-kerberos pulls in newer crypt that requires rust compiler on 3.6
     requests
     requests-kerberos
     requests_mock


### PR DESCRIPTION
Looks like an updated `cryptography` release (pulled in by `requests-kerberos`) isn't installable without a rust compiler on python 3.6.  This change caps the `cryptography` release to `<=3.2.2` (which doesn't introduce that requirement) for CI.