### PR TITLE
Cleanup for release 1.0.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,12 @@ Package documentation:
 REST API documentation: [hadoop.apache.org](http://hadoop.apache.org/docs/stable/hadoop-yarn/hadoop-yarn-site/WebServicesIntro.html)
 
 ---
-## Compatibility
-Library is compatible with Apache Hadoop __**3.2.1**__.  
+## Compatibility Matrix
+
+| yarn-api-client-python | Hadoop |
+| ------------- | ------------- |
+| 1.0.2  | 3.2.1  |
+| 1.0.3  | 3.3.0, 3.3.1  |
 
 If u have version other than mentioned (or vendored variant like Hortonworks), certain APIs might be not working or have differences in
 implementation. If u plan to use certain API long-term, you might want to make sure its not in Alpha stage in documentation.
@@ -35,6 +39,16 @@ conda install -c conda-forge yarn-api-client
 From source code
 ```
 pip install git+https://github.com/CODAIT/hadoop-yarn-api-python-client.git
+```
+
+## Enabling support for SimpleAuth
+
+See example below:
+```
+from yarn_api_client.auth import SimpleAuth
+from yarn_api_client.history_server import HistoryServer
+auth = SimpleAuth('impersonated_account_name')
+history_server = HistoryServer('https://127.0.0.2:5678', auth=auth)
 ```
 
 ## Enabling support for Kerberos/SPNEGO Security
@@ -82,6 +96,13 @@ app_information = am.application_information('application_id')
 ```
 
 ### Changelog
+
+1.0.3 Release
+   - Drop support of Python 2.7 (if you still need it for extreme emergency, look into reverting ab4f71582f8c69e908db93905485ba4d00562dfd)
+   - Update of supported hadoop version to 3.3.1
+   - Add support for YARN_CONF_DIR and HADOOP_CONF_DIR
+   - Add class for native SimpleAuth (#106)
+   - Add constructor argument for proxies (#109)
 
 1.0.2 Release
    - Add support for Python 3.8.x

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # hadoop-yarn-api-python-client
 
-Python client for Apache Hadoop® YARN API.
+Python client for Apache Hadoop® YARN API
 
 [![Latest Version](https://img.shields.io/pypi/v/yarn-api-client.svg)](https://pypi.python.org/pypi/yarn-api-client/)
 [![Downloads](https://pepy.tech/badge/yarn-api-client/month)](https://pepy.tech/project/yarn-api-client/month)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # hadoop-yarn-api-python-client
 
-Python client for Apache Hadoop® YARN API
+Python client for Apache Hadoop® YARN API.
 
 [![Latest Version](https://img.shields.io/pypi/v/yarn-api-client.svg)](https://pypi.python.org/pypi/yarn-api-client/)
 [![Downloads](https://pepy.tech/badge/yarn-api-client/month)](https://pepy.tech/project/yarn-api-client/month)
@@ -12,6 +12,8 @@ Package documentation:
 [yarn-api-client-python.readthedocs.org](https://yarn-api-client-python.readthedocs.org/en/latest/)
 
 REST API documentation: [hadoop.apache.org](http://hadoop.apache.org/docs/stable/hadoop-yarn/hadoop-yarn-site/WebServicesIntro.html)
+
+**Warning**: CLI is outdated & broken. Please don't use CLI. This will be resolved in future releases.
 
 ---
 ## Compatibility Matrix
@@ -67,7 +69,7 @@ from requests_kerberos import HTTPKerberosAuth
 history_server = HistoryServer('https://127.0.0.2:5678', auth=HTTPKerberosAuth())
 ```
 
-PS: You __**need**__ to get valid kerberos ticket in systemwide kerberos cache before running your code, otherwise calls to kerberized environment won't go through (run kinit before proceeding to run code)
+PS: You **need** to get valid kerberos ticket in systemwide kerberos cache before running your code, otherwise calls to kerberized environment won't go through (run kinit before proceeding to run code)
 
 2. Second option - using `gssapi` package  
 
@@ -76,6 +78,8 @@ If you want to avoid using terminal calls, you have to perform SPNEGO handshake 
 # Usage
 
 ### CLI interface
+
+**Warning**: CLI is outdated & broken. Please don't use CLI. This will be resolved in future releases.
 
 1. First way
 ```

--- a/setup.py
+++ b/setup.py
@@ -55,6 +55,7 @@ setup(
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
         'Topic :: System :: Distributed Computing',
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,6 @@ setup(
         'Intended Audience :: Developers',
         'License :: OSI Approved :: BSD License',
         'Operating System :: OS Independent',
-        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 
 [tox]
-envlist = py36, py37, py38, py39
+envlist = py36, py37, py38, py39, py310
 
 [gh-actions]
 python =
@@ -8,6 +8,7 @@ python =
     3.7: py37
     3.8: py38
     3.9: py39
+    3.10: py310
 
 [testenv]
 deps =

--- a/yarn_api_client/__init__.py
+++ b/yarn_api_client/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-__version__ = '2.0.0.dev0'
+__version__ = '1.0.3'
 __all__ = ['ApplicationMaster', 'HistoryServer', 'NodeManager', 'ResourceManager']
 
 from .application_master import ApplicationMaster


### PR DESCRIPTION
I've rollbacked to tree 1.0.3 because this release is not as significant to bump entire major version to 2.0.0