### PR TITLE
fix simple auth error because of ha rm api redirect

### DIFF
--- a/yarn_api_client/auth.py
+++ b/yarn_api_client/auth.py
@@ -9,10 +9,12 @@ class SimpleAuth(requests.auth.AuthBase):
     def __call__(self, request):
         if not self.auth_done:
             _session = requests.Session()
-            r = _session.get(request.url, params={"user.name": self.username})
+            r = _session.get(request.url, params={"user.name": self.username}, allow_redirects=False)
             r.raise_for_status()
-            self.auth_token = _session.cookies.get_dict()['hadoop.auth']
-            self.auth_done = True
+
+            if 'This is standby RM.' not in r.text:
+                self.auth_token = _session.cookies.get_dict()['hadoop.auth']
+                self.auth_done = True
 
         # Borrowed from https://github.com/psf/requests/issues/2532#issuecomment-90126896
         if 'Cookie' in request.headers:


### PR DESCRIPTION
the standby rm will redirect to active one when i try to initialize ResourceManager object, so that the SimpleAuth will get a standby Cookie and consider the auth is done. it only appears when i first access a standby rm.

a method to fix this is to disable redirects and then "This is standby RM." response content will be obtained.